### PR TITLE
Fix for an Auto Focus exception

### DIFF
--- a/ZBarScannerLibrary/src/com/dm/zbar/android/scanner/ZBarScannerActivity.java
+++ b/ZBarScannerLibrary/src/com/dm/zbar/android/scanner/ZBarScannerActivity.java
@@ -21,7 +21,8 @@ public class ZBarScannerActivity extends Activity implements Camera.PreviewCallb
     private Camera mCamera;
     private ImageScanner mScanner;
     private Handler mAutoFocusHandler;
-
+    private boolean complete;
+    
     static {
         System.loadLibrary("iconv");
     }
@@ -94,7 +95,7 @@ public class ZBarScannerActivity extends Activity implements Camera.PreviewCallb
         if (result != 0) {
             mCamera.setPreviewCallback(null);
             mCamera.stopPreview();
-
+            complete = true;
             SymbolSet syms = mScanner.getResults();
             for (Symbol sym : syms) {
                 String symData = sym.getData();
@@ -111,7 +112,7 @@ public class ZBarScannerActivity extends Activity implements Camera.PreviewCallb
     }
     private Runnable doAutoFocus = new Runnable() {
         public void run() {
-            if(mCamera != null) {
+            if(mCamera != null && !complete) {
                 mCamera.autoFocus(autoFocusCB);
             }
         }


### PR DESCRIPTION
I was getting an auto focus exception pretty regularly on several test phones.  It seemed to be caused by the auto focus handler still running even after the activity is complete.  This might be due to the fact that I was calling the ZBar activity from a fragment and then returning the result back to that fragment.  maybe, I dunno...but my patch makes it much more reliable for me.
