### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ I have tested the scanner functionality on these devices without any issues so f
 * HTC Thunderbolt running Android 2.3.4
 * Samsung Galaxy Nexus running Android 4.0.4
 
-###Credits
+### Credits
 Almost all of the code for this library project has been taken from these two places:
 
 1. CameraPreview app from Android SDK APIDemos 
 2. The ZBar Android SDK: http://sourceforge.net/projects/zbar/files/AndroidSDK/
 
-###License
+### License
 MIT
 
 --------------------------------------------------------------------------------------


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
